### PR TITLE
Improve/skill review optimization

### DIFF
--- a/.agents/skills/SKILL.md
+++ b/.agents/skills/SKILL.md
@@ -1,32 +1,52 @@
 ---
-name: Visualization Creation or Update
-description: Skill for creating, standardizing, or updating algorithm visualizations based on a problem ID.
+name: visualization-creation-or-update
+description: "Create, standardize, or update step-by-step algorithm visualizations for a given problem ID. Use when the user mentions 'visual', 'visualization', 'animate', or 'step-by-step' alongside a problem ID in /problem/:id format."
 ---
 
-# Visualization Creation or Update Skill
+# Visualization Creation or Update
 
-This skill is invoked when the user explicitly mentions keywords like visual, visualization (or related terms) ALONG WITH a problem ID in the format /problem/:id. Simply providing a problem ID without these keywords will not trigger the skill.
+Create or update algorithm visualizations that synchronize code execution with visual state for problems identified by `/problem/:id`.
 
-## Workflow Process
+## Workflow
 
-### 1. Locate Visualization File
-When provided /problem/:id, search for the existing visualization file in the codebase. Typical locations include src/components/visualizations/algorithms/.
-If the file exists, prepare to update it, aligning it with the latest standards.
-If the file does not exist, notify the user and ask for confirmation to generate a new visualization.
+### 1. Locate the visualization file
 
-### 2. Implementation Rules & Standards
+Search `src/components/visualizations/algorithms/` for the file matching the problem ID.
 
-When creating or updating the visualization, rigidly follow these rules:
+- **File exists**: Update it to match the standards below.
+- **File missing**: Confirm with the user before generating a new visualization.
 
-1. **Proper Code and Steps Sync:** The execution steps (logic state) MUST be perfectly synchronized with the exact lines of code being executed in the editor view.
-2. **No Code Comments:** The algorithm code block displayed to the user MUST NOT contain any comments. Remove all inline or block comments to ensure a clean, distraction-free reading experience.
-3. **Proper Commentary:** Implement descriptive, step-by-step narrative commentary for each execution step. The text should clearly explain to the coder why an action is taken and how the algorithm solves the problem.
-4. **Educational Value:** With respect to the problem description, the visualization must be intuitively designed so the coder visually and conceptually understands the algorithm's mechanics.
-5. **Instantaneous Transitions (No Click Animations):** Disable all click-based animations to ensure stable, professional, and instant visual transitions when navigating between steps.
-6. **Standardized UI/UX Layout:** Maintain consistent placement of variable panels and use intuitive geometric representations for data structures across all visualizations.
-7. **No Array Index Labels:** Do not add "idx" labels (or similar index markings) to array visual elements. Keep the array representations clean.
-8. **Text Color:** Ensure the color of the text used in visualizations is black for maximum clarity and contrast.
+### 2. Implement the visualization
 
-### 3. Verification
-Double-check that there are absolutely no comments inside the code block string.
-Verify array/pointer/variable states correspond exactly to the active execution step.
+#### Code display rules
+
+- The execution steps MUST be perfectly synchronized with the highlighted lines of code in the editor view.
+- The algorithm code block MUST NOT contain any comments — remove all inline and block comments.
+- Always use the `AnimatedCodeEditor` component for code blocks. Do not add redundant wrapper `div`s, headings, or extra layout containers around it.
+
+#### Layout rules
+
+- Place `SimpleStepControls` at the top of the visualization, above the main content grid.
+- Use a two-column grid on large screens with consistent `VariablePanel` placement.
+- Place the descriptive commentary box above the `VariablePanel` to provide immediate context.
+- Use theme-aware text classes (`text-foreground`, `text-primary-foreground`) instead of hardcoded colors.
+- Do not add index labels (e.g., "idx") to array visual elements.
+
+#### Interaction rules
+
+- Disable all click-based animations — transitions between steps must be instantaneous.
+- Only implement multiple test cases if explicitly requested. When implemented, provide a visually polished toggle UI using `lucide-react` icons. Switching cases must reset `currentStepIndex` to 0 and `isPlaying` to false.
+
+#### Commentary rules
+
+- Write descriptive, step-by-step narrative commentary explaining *why* each action is taken and *how* the algorithm progresses toward the solution.
+
+### 3. Verify
+
+Confirm each of the following before completing:
+
+- [ ] No comments inside the code block string
+- [ ] Variable/pointer states match the active execution step at every step index
+- [ ] `SimpleStepControls` renders above the content grid
+- [ ] `AnimatedCodeEditor` has no redundant wrapper elements
+- [ ] Text colors use theme-aware classes

--- a/.agents/skills/security/SKILL.md
+++ b/.agents/skills/security/SKILL.md
@@ -1,35 +1,55 @@
 ---
-name: Security Scan
-description: Skill for scanning the repository for sensitive data, keys, network vulnerabilities, and cyber attack patterns.
+name: security-scan
+description: "Scan the repository for hardcoded secrets, exposed API keys, insecure network configurations, and vulnerable dependencies. Use when the user asks for a security audit, secret detection, credential scan, vulnerability check, or wants to find leaked tokens in the codebase."
 ---
 
-# Security Scan Skill
+# Security Scan
 
-This skill is invoked when the user requests a security audit, a scan for secrets, or checks for network vulnerabilities. Keywords: `security scan`, `audit`, `secrets`, `leaks`, `vulnerabilities`.
+Detect hardcoded secrets, insecure network patterns, and vulnerable dependencies in the repository using integrated scanning scripts.
 
-## Workflow Process
+## Workflow
 
-### 1. Preparation
-- Ensure all dependencies for the scanning scripts are available (Python, Shell).
-- Identify the scope of the scan (entire repo or specific subdirectories).
+### 1. Determine scope
 
-### 2. Execution
-Run the integrated security scan using the provided scripts:
-- **Secret Detection**: Checks for hardcoded API keys, tokens, and credentials.
-- **Network Check**: Identifies hardcoded IP addresses and usage of insecure protocols (e.g., `http://` where `https://` is expected).
-- **Dependency Audit**: Runs `npm audit` to find vulnerable packages.
+Identify whether to scan the entire repo or specific subdirectories based on the user request.
 
-### 3. Reporting
-- Organize findings into a clear, formatted report in the chat.
-- Categorize issues by severity: **High**, **Medium**, **Low**.
-- Provide actionable advice for each finding (e.g., "Rotate this key", "Upgrade this package").
+### 2. Run the scan
 
-### 4. Safety First
-- **IMPORTANT**: If a real secret is found, DO NOT display the full secret in the chat. Mask it (e.g., `AKIA...XXXX`).
-- Warn the user about the risks of committing secrets to the repository.
-
-## Commands
-The primary command to run the full scan is:
 ```bash
 bash .agents/skills/security/scripts/main_scan.sh
 ```
+
+The scan checks three categories:
+
+- **Secret detection**: Hardcoded API keys, tokens, passwords, and credentials (e.g., patterns like `AKIA`, `sk-`, `ghp_`, `Bearer`)
+- **Network check**: Hardcoded IP addresses and insecure protocol usage (`http://` where `https://` is expected)
+- **Dependency audit**: `npm audit` for vulnerable packages
+
+If the main script is unavailable, run checks manually:
+
+```bash
+# Secret patterns
+grep -rn "AKIA\|sk-\|ghp_\|password\s*=\|api_key\s*=" --include="*.ts" --include="*.js" --include="*.env" .
+
+# Insecure protocols
+grep -rn "http://" --include="*.ts" --include="*.js" . | grep -v localhost
+
+# Dependency vulnerabilities
+npm audit --json
+```
+
+### 3. Report findings
+
+Organize results by severity:
+
+| Severity | Examples |
+|----------|----------|
+| **High** | Exposed API keys, hardcoded passwords, leaked tokens |
+| **Medium** | Insecure protocol usage, hardcoded IPs in production code |
+| **Low** | Outdated dependencies with low-severity CVEs |
+
+Provide actionable remediation for each finding (e.g., "Rotate this key and move to environment variable", "Upgrade package X to version Y").
+
+### 4. Safety
+
+**CRITICAL**: Never display a full secret in the output. Mask all sensitive values (e.g., `AKIA...XXXX`, `sk-...abcd`). Warn the user about the risk of committing secrets to version control.

--- a/.agents/skills/visualization/SKILL.md
+++ b/.agents/skills/visualization/SKILL.md
@@ -1,37 +1,52 @@
 ---
-name: Visualization Creation or Update
-description: Skill for creating, standardizing, or updating algorithm visualizations based on a problem ID.
+name: visualization-creation-or-update
+description: "Create, standardize, or update step-by-step algorithm visualizations for a given problem ID. Use when the user mentions 'visual', 'visualization', 'animate', or 'step-by-step' alongside a problem ID in /problem/:id format."
 ---
 
-# Visualization Creation or Update Skill
+# Visualization Creation or Update
 
-This skill is invoked when the user explicitly mentions keywords like `visual`, `visualization` (or related terms) ALONG WITH a problem ID in the format `/problem/:id`. Simply providing a problem ID without these keywords will not trigger the skill.
+Create or update algorithm visualizations that synchronize code execution with visual state for problems identified by `/problem/:id`.
 
-## Workflow Process
+## Workflow
 
-### 1. Locate Visualization File
-- When provided `/problem/:id`, search for the existing visualization file in the codebase. Typical locations include `src/components/visualizations/algorithms/`.
-- If the file exists, prepare to update it, aligning it with the latest standards.
-- If the file does not exist, notify the user and ask for confirmation to generate a new visualization.
+### 1. Locate the visualization file
 
-### 2. Implementation Rules & Standards
+Search `src/components/visualizations/algorithms/` for the file matching the problem ID.
 
-When creating or updating the visualization, rigidly follow these rules:
+- **File exists**: Update it to match the standards below.
+- **File missing**: Confirm with the user before generating a new visualization.
 
-1. **Proper Code and Steps Sync:** The execution steps (logic state) MUST be perfectly synchronized with the exact lines of code being executed in the editor view.
-2. **No Code Comments:** The algorithm code block displayed to the user MUST NOT contain any comments. Remove all inline or block comments to ensure a clean, distraction-free reading experience.
-3. **Proper Commentary:** Implement descriptive, step-by-step narrative commentary for each execution step. The text should clearly explain to the coder *why* an action is taken and *how* the algorithm solves the problem.
-4. **Educational Value:** With respect to the problem description, the visualization must be intuitively designed so the coder visually and conceptually understands the algorithm's mechanics.
-5. **Instantaneous Transitions (No Click Animations):** Disable all click-based animations to ensure stable, professional, and instant visual transitions when navigating between steps.
-6. **Standardized UI/UX Layout:** Maintain consistent placement of variable panels and use intuitive geometric representations for data structures. The layout should typically be a two-column grid on large screens.
-7. **No Array Index Labels:** Do not add "idx" labels (or similar index markings) to array visual elements. Keep the array representations clean.
-8. **Text Color:** Ensure the color of the text used in visualizations has high contrast with its background and respects dark mode by using theme-aware classes (e.g., `text-foreground`, `text-primary-foreground`).
-9. **Top-Aligned Controls:** The `SimpleStepControls` component MUST be placed at the top of the visualization, above the main content grid, to ensure immediate user access to navigation.
-10. **Use AnimatedCodeEditor:** Always use the `AnimatedCodeEditor` component when an implementation code block is required within the visualization.
-11. **Minimal Code Editor Container:** Do NOT include a redundant `div` wrapper, "Implementation" heading, or extra layout containers (like `flex-1 overflow-auto`) within the `Card` that encloses the `AnimatedCodeEditor`. The editor should be the primary child of its container card.
-12. **Test Case Selection:** Only implement multiple test cases (and the selection UI) if explicitly requested by the user. If not requested, one robust default case is sufficient. When multiple cases ARE requested, provide a premium, visually stunning UI (e.g., an animated sliding toggle with icons from `lucide-react`) to switch between them. Switching cases MUST reset the execution state (`currentStepIndex` back to 0, `isPlaying` to false). Place these controls at the top, typically next to or just below the `StepControls`.
-13. **Pedagogical Layout:** Ensure that the descriptive commentary box is placed **above** the `VariablePanel` to provide immediate context for the current state.
+### 2. Implement the visualization
 
-### 3. Verification
-- Double-check that there are absolutely no comments inside the code block string.
-- Verify array/pointer/variable states correspond exactly to the active execution step.
+#### Code display rules
+
+- The execution steps MUST be perfectly synchronized with the highlighted lines of code in the editor view.
+- The algorithm code block MUST NOT contain any comments — remove all inline and block comments.
+- Always use the `AnimatedCodeEditor` component for code blocks. Do not add redundant wrapper `div`s, headings, or extra layout containers around it.
+
+#### Layout rules
+
+- Place `SimpleStepControls` at the top of the visualization, above the main content grid.
+- Use a two-column grid on large screens with consistent `VariablePanel` placement.
+- Place the descriptive commentary box above the `VariablePanel` to provide immediate context.
+- Use theme-aware text classes (`text-foreground`, `text-primary-foreground`) instead of hardcoded colors.
+- Do not add index labels (e.g., "idx") to array visual elements.
+
+#### Interaction rules
+
+- Disable all click-based animations — transitions between steps must be instantaneous.
+- Only implement multiple test cases if explicitly requested. When implemented, provide a visually polished toggle UI using `lucide-react` icons. Switching cases must reset `currentStepIndex` to 0 and `isPlaying` to false.
+
+#### Commentary rules
+
+- Write descriptive, step-by-step narrative commentary explaining *why* each action is taken and *how* the algorithm progresses toward the solution.
+
+### 3. Verify
+
+Confirm each of the following before completing:
+
+- [ ] No comments inside the code block string
+- [ ] Variable/pointer states match the active execution step at every step index
+- [ ] `SimpleStepControls` renders above the content grid
+- [ ] `AnimatedCodeEditor` has no redundant wrapper elements
+- [ ] Text colors use theme-aware classes

--- a/.claude/skills/integration-react-native/SKILL.md
+++ b/.claude/skills/integration-react-native/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: integration-react-native
-description: PostHog integration for React Native applications
+description: "Install and configure PostHog analytics SDK in React Native applications, including event tracking, feature flags, user identification, and error tracking. Use when the user needs to add PostHog analytics, session recording, or feature flags to a React Native app."
 metadata:
   author: PostHog
   version: 1.9.5
 ---
 
-# PostHog integration for React Native
+# PostHog Integration for React Native
 
-This skill helps you add PostHog analytics to React Native applications.
+Set up PostHog analytics in a React Native application: install the SDK, configure the provider, implement event tracking, identify users, and add error tracking.
 
 ## Workflow
 
-Follow these steps in order to complete the integration:
+Follow these steps in order:
 
-1. `basic-integration-1.0-begin.md` - PostHog Setup - Begin ← **Start here**
+1. `basic-integration-1.0-begin.md` - PostHog Setup - Begin **Start here**
 2. `basic-integration-1.1-edit.md` - PostHog Setup - Edit
 3. `basic-integration-1.2-revise.md` - PostHog Setup - Revise
 4. `basic-integration-1.3-conclude.md` - PostHog Setup - Conclusion
@@ -22,32 +22,45 @@ Follow these steps in order to complete the integration:
 ## Reference files
 
 - `references/EXAMPLE.md` - React Native example project code
-- `references/react-native.md` - React native - docs
-- `references/identify-users.md` - Identify users - docs
-- `references/basic-integration-1.0-begin.md` - PostHog setup - begin
-- `references/basic-integration-1.1-edit.md` - PostHog setup - edit
-- `references/basic-integration-1.2-revise.md` - PostHog setup - revise
-- `references/basic-integration-1.3-conclude.md` - PostHog setup - conclusion
-
-The example project shows the target implementation pattern. Consult the documentation for API details.
-
-## Key principles
-
-- **Environment variables**: Always use environment variables for PostHog keys. Never hardcode them.
-- **Minimal changes**: Add PostHog code alongside existing integrations. Don't replace or restructure existing code.
-- **Match the example**: Your implementation should follow the example project's patterns as closely as possible.
+- `references/react-native.md` - React Native SDK docs
+- `references/identify-users.md` - User identification docs
 
 ## Framework guidelines
 
-- posthog-react-native is the React Native SDK package name
-- Use react-native-config to load POSTHOG_PROJECT_TOKEN and POSTHOG_HOST from .env (variables are embedded at build time, not runtime)
-- react-native-svg is a required peer dependency of posthog-react-native (used by the surveys feature) and must be installed alongside it
-- Place PostHogProvider INSIDE NavigationContainer for React Navigation v7 compatibility
+- Install `posthog-react-native` and its required peer dependency `react-native-svg`
+- Use `react-native-config` to load `POSTHOG_PROJECT_TOKEN` and `POSTHOG_HOST` from `.env` (embedded at build time, not runtime)
+- Place `PostHogProvider` INSIDE `NavigationContainer` for React Navigation v7 compatibility
+
+Minimal provider setup:
+
+```tsx
+import PostHog, { PostHogProvider } from 'posthog-react-native';
+import Config from 'react-native-config';
+
+const posthogClient = new PostHog(Config.POSTHOG_PROJECT_TOKEN, {
+  host: Config.POSTHOG_HOST,
+});
+
+// Inside your App component, wrap content within NavigationContainer:
+<NavigationContainer>
+  <PostHogProvider client={posthogClient}>
+    {/* app content */}
+  </PostHogProvider>
+</NavigationContainer>
+```
 
 ## Identifying users
 
-Identify users during login and signup events. Refer to the example code and documentation for the correct identify pattern for this framework. If both frontend and backend code exist, pass the client-side session and distinct ID using `X-POSTHOG-DISTINCT-ID` and `X-POSTHOG-SESSION-ID` headers to maintain correlation.
+Identify users during login and signup events. Pass the client-side session and distinct ID using `X-POSTHOG-DISTINCT-ID` and `X-POSTHOG-SESSION-ID` headers to maintain frontend/backend correlation. Refer to `references/identify-users.md` and `references/EXAMPLE.md` for the correct pattern.
 
 ## Error tracking
 
-Add PostHog error tracking to relevant files, particularly around critical user flows and API boundaries.
+Add PostHog error tracking around critical user flows and API boundaries. Capture errors with `posthog.capture('$exception', { $exception_message: error.message })`.
+
+## Verification
+
+After completing the integration:
+
+1. Run the app and trigger a test event
+2. Confirm the event appears in the PostHog project dashboard within 60 seconds
+3. Verify user identification by checking the "Persons" tab for the identified user

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,13 @@
+name: Skill Review
+on:
+  pull_request:
+    paths: ['**/SKILL.md']
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@22e928dd837202b2b1d1397e0114c92e0fae5ead # main

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,152 +1,44 @@
-# RulCode
-
-**Master Technical Interviews with Confidence**
-
-RulCode is a platform designed to help developers prepare for technical interviews through structured practice, clean explanations, and real-world coding challenges.
-
-Inspired by the clean learning experience of modern developer platforms and the structured problem-solving approach of competitive coding sites, RulCode aims to make interview preparation simple, focused, and effective.
-
+---
+name: rulcode-development
+description: "Develop and extend the RulCode technical interview preparation platform built with React, Vite, TypeScript, and Supabase. Use when adding new algorithm problems, building visualization components, implementing DSA topic pages, updating the problem editor, or modifying the interview preparation UI."
 ---
 
-## 🚀 Vision
+# RulCode Development
 
-Technical interviews should not feel overwhelming.
+Build and extend the RulCode platform — a React/Vite/TypeScript application for technical interview preparation covering DSA, system design, and frontend concepts.
 
-RulCode is built to help developers:
+## Workflow
 
-* Practice consistently
-* Learn concepts clearly
-* Build confidence for interviews
-* Master problem-solving skills step by step
+### 1. Understand the request
 
-Our goal is to create a **complete interview preparation ecosystem**.
+Identify which area of the platform the change targets:
 
----
+- **Algorithm problems**: Adding or editing problems in `src/` covering arrays, strings, hashing, two pointers, sliding window, recursion, backtracking, trees, graphs, dynamic programming, and greedy algorithms
+- **Visualizations**: Step-by-step algorithm animations (see `.agents/skills/visualization/SKILL.md`)
+- **UI components**: React components using Tailwind CSS and shadcn/ui (`components.json`)
+- **Backend/data**: Supabase integration in `supabase/`
 
-## ✨ Current Features
+### 2. Set up the development environment
 
-### 📚 Data Structures & Algorithms (DSA)
+```bash
+npm install
+npm run dev
+```
 
-Practice common interview problems with:
+The project uses Vite (`vite.config.ts`) with TypeScript (`tsconfig.json`) and Tailwind CSS (`tailwind.config.ts`).
 
-* Multiple difficulty levels
-* Clear explanations
-* Optimized solutions
-* Multiple language support
-* Real interview-style problems
+### 3. Implement the change
 
-Topics include:
+- Follow existing patterns in `src/` for component structure and naming
+- Use TypeScript strict mode conventions from `tsconfig.app.json`
+- Lint with ESLint (`eslint.config.js`)
+- Problems support multiple difficulty levels and multiple language implementations
 
-* Arrays
-* Strings
-* Hashing
-* Two Pointers
-* Sliding Window
-* Recursion
-* Backtracking
-* Trees
-* Graphs
-* Dynamic Programming
-* Greedy Algorithms
+### 4. Verify
 
----
+```bash
+npm run build
+npm run lint
+```
 
-## 🧠 What Makes RulCode Different
-
-* **Clean and distraction-free UI**
-* **Structured interview preparation**
-* **Concept-first learning**
-* **Real coding practice**
-* **Beginner → Advanced roadmap**
-
-We focus on helping developers **understand the thinking process**, not just memorize solutions.
-
----
-
-## 🔮 Upcoming Features
-
-RulCode will expand beyond DSA to cover the complete interview journey.
-
-### 🏗 System Design
-
-* High-level architecture
-* Scalability concepts
-* Real-world system design interviews
-
-### 🎨 Frontend Interview Preparation
-
-* JavaScript interview questions
-* DOM & browser concepts
-* React interview questions
-* Angular interview questions
-* UI architecture problems
-
-### ⚙️ Real Interview Simulations
-
-* Timed coding challenges
-* Mock interview environments
-* Company-specific questions
-
-### 📈 Progress Tracking
-
-* Skill progress dashboard
-* Topic mastery tracking
-* Interview readiness score
-
----
-
-## 🎯 Who Is This For?
-
-RulCode is designed for:
-
-* Developers preparing for **product-based companies**
-* Frontend engineers preparing for **React / Angular interviews**
-* Engineers strengthening their **DSA fundamentals**
-* Developers who want **structured interview preparation**
-
----
-
-## 💻 Tech Philosophy
-
-RulCode focuses on:
-
-* Simplicity
-* Performance
-* Clean UI
-* Structured learning
-* Developer-first experience
-
----
-
-## 🌍 Future Goal
-
-To build one of the **best platforms for technical interview preparation**, combining:
-
-* Coding practice
-* System design
-* Frontend architecture
-* Real interview experiences
-
-All in **one clean and powerful platform**.
-
----
-
-## 🔗 Website
-
-**Coming Soon**
-
-https://rulcode.com
-
----
-
-## ⭐ Contribute
-
-Contributions, ideas, and feedback are welcome.
-
-Together we can build a platform that helps developers succeed in technical interviews.
-
----
-
-## 📌 Tagline
-
-**"Prepare Smart. Code Better. Crack Interviews."**
+Check that the dev server renders the change correctly at the target route.


### PR DESCRIPTION
Hey @rkmahale17 👋

Skills spread across .claude/skills/ and .agents/skills/ with dedicated integration paths for React Native and React Router. You're clearly thinking about multi-agent compatibility from the ground up. The structured algorithm index on rulcode.com with 40+ patterns across 8 categories is impressively comprehensive for an interview prep platform. Wanted to suggest a few improvements to the SKILL.md.

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

<img width="1312" height="986" alt="score_card" src="https://github.com/user-attachments/assets/9217de5d-7299-4518-af37-b79981e6809e" />

<details>
<summary>Changes made</summary>

Root SKILL.md (10% → 80%)
- Added proper YAML frontmatter with name and description fields (was completely missing)
- Restructured from a README/vision document into a proper skill with clear workflow steps
- Added "Use when..." trigger clause covering algorithm problems, visualizations, DSA pages, and UI changes
- Added concrete dev commands (npm install, npm run dev, npm run build, npm run lint)
- Reduced from 153 lines to 45 focused lines

visualization-creation-or-update — .agents/skills/SKILL.md (53% → 90%)
- Fixed name from "Visualization Creation or Update" to kebab-case
- Expanded description with explicit "Use when..." clause and natural trigger terms
- Reorganized 8 implementation rules into clear categories: code display, layout, interaction, commentary
- Added explicit verification checklist with checkboxes
- Removed meta-trigger text from body (moved to description)

security-scan (53% → 97%)
- Fixed name from "Security Scan" to kebab-case
- Expanded description with "Use when..." clause covering audit, secret detection, credential scan, vulnerability check, leaked tokens
- Added concrete fallback grep patterns for when the main scan script is unavailable
- Added severity table with example findings per level
- Removed meta-description opening and Keywords line from body
- Added specific remediation examples

visualization-creation-or-update - .agents/skills/visualization/SKILL.md (53% → 90%)
- Same improvements as the .agents/skills/ version (these are companion skills)
- Fixed name, expanded description, reorganized rules, added verification checklist

integration-react-native (52% → 95%)
- Expanded description from 49 to 264 chars with concrete actions
- Added "Use when..." clause with natural triggers (analytics, session recording, feature flags)
- Added inline PostHogProvider code example for immediate actionability
- Added concrete error capture snippet
- Added verification section with 3 specific checkpoints
- Streamlined reference file list

</details>

---

Honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

I also added a lightweight GitHub Action that auto-reviews any skill.md changed in a PR (includes min permissions, uses a pinned action version, only posts a review comment).

This means that it gives you and your contributors an instant quality signal before you have to review yourself (no signup, no tokens needed).

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at this Tessl guide (https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - @yogesh-tessl (https://github.com/yogesh-tessl) - if you hit any snags.

Thanks in advance 🙏